### PR TITLE
Allow spaces in the file path for NUnit test dll.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+
+jobs:
+  release:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2.3.2
+    - uses: microsoft/setup-msbuild@v1.0.1
+    - uses: actions/setup-node@v1.4.3
+    - run: |
+        npm version "${{ github.event.inputs.version }}"
+        .\makefile.bat
+    - uses: actions/create-release@v1
+      id: create_release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ github.event.inputs.version }}
+        release_name: Release v${{ github.event.inputs.version }}
+    - uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./vscode-nxunit-test-adapter-${{ github.event.inputs.version }}.vsix
+        asset_name: vscode-nxunit-test-adapter-${{ github.event.inputs.version }}.vsix
+        asset_content_type: application/zip

--- a/src/cs/Program.cs
+++ b/src/cs/Program.cs
@@ -567,7 +567,7 @@ class Program {
 		List<TestCase> lst = new List<TestCase>();
 
 		if (run==0) {
-			args = f + " --explore="+tmps;
+			args = '"' + f + '"' + " --explore="+tmps;
 		} else {
 			if (types != null && types.Count > 0) {
 				m = string.Join(",", types);
@@ -579,7 +579,7 @@ class Program {
 			}
 			if (m != null)
 				m = "--test="+m;
-			args = f  +' '+m + " --inprocess" + " --result="+tmps;
+			args = '"' + f + '"' +' '+m + " --inprocess" + " --result="+tmps;
 
 		}
 

--- a/src/cs/Program.cs
+++ b/src/cs/Program.cs
@@ -39,7 +39,6 @@ class Program {
 
 		public void Print(int run)
 		{
-			Console.OutputEncoding = Encoding.UTF8;
 			if (run == 0)
 				Console.WriteLine("{0};{1}", type, modname);
 
@@ -201,6 +200,8 @@ class Program {
 			Console.Error.WriteLine("Unit runners missing");
 			return;
 		}
+
+		Console.OutputEncoding = Encoding.UTF8;
 
 		if (runmode==0)
 			ltest = ProcessTests(runmode, target,ltest);

--- a/src/cs/Program.cs
+++ b/src/cs/Program.cs
@@ -39,6 +39,7 @@ class Program {
 
 		public void Print(int run)
 		{
+			Console.OutputEncoding = Encoding.UTF8;
 			if (run == 0)
 				Console.WriteLine("{0};{1}", type, modname);
 


### PR DESCRIPTION
If there are spaces in the file path being tested, they cannot be discover.