### PR TITLE
Add support for running tests with string arguments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "publish": "vsce publish"
   },
   "dependencies": {
+    "@types/node": "^15.9.0",
     "tslib": "^1.9.3",
     "vscode-test-adapter-api": "^1.1.0",
     "vscode-test-adapter-util": "^0.5.1"

--- a/src/cs/Program.cs
+++ b/src/cs/Program.cs
@@ -515,7 +515,7 @@ class Program {
 			foreach(var m in methods) {
 				//method(ss) to method
 				var s = m.Substring(0,m.IndexOf('(') == -1? m.Length:m.IndexOf('('));
-				args += " -method " + s;
+				args += " -method \"" + s.Replace ("\"", "\\\"") + "\"";
 			}
 			cons += '|'+ string.Join("|", methods.ToArray());
 		}
@@ -525,7 +525,7 @@ class Program {
 			aargs = " --debug " +  xrunner +' ' + f + args + " -xml " + tmps;
 		} else {
 			exe = xrunner;
-			aargs = f + args + " -xml " + tmps;
+			aargs = $"\"{f}\"" + args + " -xml " + tmps;
 		}
 
 		if (run==1) {	//run tests
@@ -578,8 +578,8 @@ class Program {
 				cons += "|" + string.Join("|", methods);
 			}
 			if (m != null)
-				m = "--test="+m;
-			args = f  +' '+m + " --inprocess" + " --result="+tmps;
+				m = "--test=\""+m.Replace ("\"", "\\\"")+"\"";
+			args = $"\"{f}\""  +' '+m + " --inprocess" + " --result="+tmps;
 
 		}
 


### PR DESCRIPTION
There is an issue where if a unit test uses string arguments the test would not run or debug in 
vscode. This is because the arguments need to be escaped so that when we pass them to 
`nunit-console` they are not removed by the command line parser. 
I assume the same will happen under `xunit`.

Also upgraded `package.json` to include  `@types/node` as the project would not build without it.